### PR TITLE
Fix readme usage example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,12 +29,12 @@ imageType(buffer);
 Or from a remote location:
 
 ```js
-const http = require('http');
+const https = require('https');
 const imageType = require('image-type');
 
-const url = 'https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif';
+const url = 'https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg';
 
-http.get(url, response => {
+https.get(url, response => {
 	response.on('readable', () => {
 		const chunk = response.read(imageType.minimumBytes);
 		response.destroy();


### PR DESCRIPTION
We are requesting a https resource so we must use **https**.get()

Additionally, the old image is 404'ing.  Replaced with another image url.