### PR TITLE
Update to example with `imageType.minimumBytes` in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,9 @@ npm install image-type
 
 ```js
 import {readChunk} from 'read-chunk';
-import imageType from 'image-type';
+import imageType, {minimumBytes as imageTypeMinBytes} from 'image-type';
 
-const buffer = await readChunk('unicorn.png', {length: 12});
+const buffer = await readChunk('unicorn.png', {length: imageTypeMinBytes});
 
 await imageType(buffer);
 //=> {ext: 'png', mime: 'image/png'}
@@ -28,14 +28,14 @@ Or from a remote location:
 
 ```js
 import https from 'node:https';
-import imageType from 'image-type';
+import imageType, {minimumBytes as imageTypeMinBytes} from 'image-type';
 
 const url = 'https://upload.wikimedia.org/wikipedia/en/a/a9/Example.jpg';
 
 https.get(url, response => {
 	response.on('readable', () => {
 		(async () => {
-			const chunk = response.read(imageType.minimumBytes);
+			const chunk = response.read(imageTypeMinBytes);
 			response.destroy();
 			console.log(await imageType(chunk));
 			//=> {ext: 'jpg', mime: 'image/jpeg'}


### PR DESCRIPTION
 `imageType.minimumBytes` does not exist, with `import imageType from 'image-type'` (Since the default export in index.js is the function `imageType(input) { ... }`)

**So** the import statement should be:
`import imageType, {  minimumBytes  } from 'image-type';` Or
`import imageType, {  minimumBytes as imageTypeMinBytes } from 'image-type';`

**And** the `minimumBytes` should be used as:
`const chunk = response.read(minimumBytes)`


Side note:
- The README.md should the bytes used in the `read-chunk` example be updated to `imageTypeMinBytes` too, instead of 12 ?
    - i.e Use `const buffer = await readChunk('unicorn.png', {length: imageTypeMinBytes});`