### PR TITLE
Goodbye, node.js Buffer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,3 @@
-import {type Buffer} from 'node:buffer';
-
 export type ImageFileExtension =
 	| 'jpg'
 	| 'png'
@@ -34,7 +32,7 @@ export type ImageTypeResult = {
 };
 
 /**
-Detect the image type of a `Buffer`/`Uint8Array`.
+Detect the image type of an `ArrayBuffer`/`Uint8Array`.
 
 @param input - Input for which to determine the file type. It only needs the first `minimumBytes` amount of bytes.
 
@@ -68,8 +66,7 @@ https.get(url, response => {
 });
 ```
 */
-// eslint-disable-next-line @typescript-eslint/ban-types -- TODO: Switch to Uint8Array only
-export default function imageType(input: Buffer | Uint8Array): Promise<ImageTypeResult | undefined>;
+export default function imageType(input: ArrayBuffer | Uint8Array): Promise<ImageTypeResult | undefined>;
 
 /**
 The minimum amount of bytes needed to detect a file type. Currently, it's 4100 bytes, but it can change, so don't hard-code it.

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,14 +1,11 @@
-import {Buffer} from 'node:buffer';
 import {expectType} from 'tsd';
 import imageType, {minimumBytes, type ImageTypeResult, type ImageFileExtension} from './index.js';
 
-await imageType(Buffer.from([0xFF, 0xD8, 0xFF]));
 await imageType(new Uint8Array([0xFF, 0xD8, 0xFF]));
 
-expectType<Promise<ImageTypeResult | undefined>>(imageType(Buffer.from([0xFF, 0xD8, 0xFF])));
 expectType<Promise<ImageTypeResult | undefined>>(imageType(new Uint8Array([0xFF, 0xD8, 0xFF])));
 
-const result = await imageType(Buffer.from([0xFF, 0xD8, 0xFF]));
+const result = await imageType(new Uint8Array([0xFF, 0xD8, 0xFF]));
 if (result !== undefined) {
 	expectType<ImageFileExtension>(result.ext);
 	expectType<string>(result.mime);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "image-type",
 	"version": "5.2.0",
-	"description": "Detect the image type of a Buffer/Uint8Array",
+	"description": "Detect the image type of an ArrayBuffer/Uint8Array",
 	"license": "MIT",
 	"repository": "sindresorhus/image-type",
 	"funding": "https://github.com/sponsors/sindresorhus",

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # image-type
 
-> Detect the image type of a Buffer/Uint8Array
+> Detect the image type of an ArrayBuffer/Uint8Array
 
 See the [`file-type`](https://github.com/sindresorhus/file-type) module for more file types and a CLI.
 
@@ -74,7 +74,7 @@ Or `undefined` when there is no match.
 
 #### input
 
-Type: `Buffer | Uint8Array`
+Type: `ArrayBuffer | Uint8Array`
 
 It only needs the first `minimumBytes` amount of bytes.
 


### PR DESCRIPTION
See - https://sindresorhus.com/blog/goodbye-nodejs-buffer

If you'd prefer to only accept Uint8Array, I can update. I made it match what `file-type` accepts.