### PR TITLE
update file-type to v19, require node v18+

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
         node-version:
           - 20
           - 18
-          - 16
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 	"types": "./index.d.ts",
 	"sideEffects": false,
 	"engines": {
-		"node": ">=14.16"
+		"node": ">=18"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -48,7 +48,7 @@
 		"mime"
 	],
 	"dependencies": {
-		"file-type": "^18.1.0"
+		"file-type": "^19.0.0"
 	},
 	"devDependencies": {
 		"@types/node": "^18.11.18",


### PR DESCRIPTION
Update `file-type` to the latest version and use the same minimum node version requirement as it.